### PR TITLE
Fix: Password Visibility Toggle button visibility

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -48,6 +48,7 @@
         android:layout_height="wrap_content"
         android:hint="@string/hint_password"
         android:padding="@dimen/space_small"
+        app:passwordToggleEnabled="true"
         app:layout_constraintBottom_toTopOf="@id/button_login"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
**Fix: Password Field Secure Text Visibility option not showing**

Fixed by enabling the Password Visibility Toggle attribute in the Password Text Input Layout